### PR TITLE
feat(player): add get and set volume levels as percentages

### DIFF
--- a/src/output/human.rs
+++ b/src/output/human.rs
@@ -99,8 +99,9 @@ pub fn now_playing(status: PlayerStatus) -> Result<()> {
 fn playback_context_line(status: &PlayerStatus) -> Option<String> {
     let repeat = status.repeat_state.as_deref();
     let shuffle = status.shuffle_state;
+    let volume = status.device.as_ref().and_then(|d| d.volume_percent);
 
-    if repeat.is_none() && shuffle.is_none() {
+    if repeat.is_none() && shuffle.is_none() && volume.is_none() {
         return None;
     }
 
@@ -110,10 +111,13 @@ fn playback_context_line(status: &PlayerStatus) -> Option<String> {
         Some(false) => "off",
         None => "unknown",
     };
+    let volume_text = volume
+        .map(|v| format!("{}%", v))
+        .unwrap_or_else(|| "unknown".to_string());
 
     Some(format!(
-        "repeat: {}, shuffle: {}",
-        repeat_text, shuffle_text
+        "repeat: {}, shuffle: {}, volume: {}",
+        repeat_text, shuffle_text, volume_text
     ))
 }
 

--- a/src/spotify/playback.rs
+++ b/src/spotify/playback.rs
@@ -99,6 +99,11 @@ impl PlaybackClient {
         self.send(Method::PUT, &path, None)
     }
 
+    pub fn set_volume(&self, percent: u32) -> Result<()> {
+        let path = format!("/me/player/volume?volume_percent={}", percent);
+        self.send(Method::PUT, &path, None)
+    }
+
     pub fn queue(&self, limit: u32) -> Result<QueueState> {
         let token = self.auth.token()?;
         let url = format!("{}/me/player/queue", api_base());


### PR DESCRIPTION
This pull request adds support for viewing and setting the playback volume from the CLI, and improves the display of playback context information by including the current volume. The main changes introduce a new `Volume` command, update the output to show volume, and add an API method for setting the volume.

**CLI enhancements:**

* Added a new `PlayerCommand::Volume` variant to allow users to view or set the playback volume from the CLI. If a percentage is provided, it sets the volume; if omitted, it displays the current volume. Input is validated to ensure the value is between 0 and 100. (`src/cli/player.rs`) [[1]](diffhunk://#diff-32880fa0c3ca1665af72d026821abc71712714a098c5e4ea89a5707230a510c6R24-R27) [[2]](diffhunk://#diff-32880fa0c3ca1665af72d026821abc71712714a098c5e4ea89a5707230a510c6R74-R93)

**Playback API:**

* Introduced a new `set_volume` method in the `PlaybackClient` to update the playback volume via the Spotify API. (`src/spotify/playback.rs`)

**Output improvements:**

* Updated the playback context line in the output to display the current volume alongside repeat and shuffle state, defaulting to "unknown" if not available. (`src/output/human.rs`) [[1]](diffhunk://#diff-863a991bb5261d702f299520d098e415d00f8e7b0cc82ebb0c61014c802cd83eR102-R104) [[2]](diffhunk://#diff-863a991bb5261d702f299520d098e415d00f8e7b0cc82ebb0c61014c802cd83eR114-R120)