### PR TITLE
Fix: Remove hardcoded limit ignoring CLI --limit flag

### DIFF
--- a/src/io/formatters/library.rs
+++ b/src/io/formatters/library.rs
@@ -6,7 +6,7 @@ use crate::io::common::extract_artist_names;
 
 pub fn format_saved_tracks(items: &[Value]) {
     println!("Saved Tracks:");
-    for (i, item) in items.iter().take(20).enumerate() {
+    for (i, item) in items.iter().enumerate() {
         if let Some(track) = item.get("track") {
             let name = track
                 .get("name")


### PR DESCRIPTION
Removed a hardcoded method call that was overriding the --limit argument in the CLI.

The issue:
Currently, the program ignores the limit value passed by the user. For example, running: spotify-cli -vvv lib list --limit 50
...still returns a default/restricted number of items because the hardcoded call takes precedence, resulting in incomplete data output.

The fix:
Removed the redundant hardcoded call so the program correctly respects the --limit flag (or any other provided key) from the command line.

Tested with the command above and verified that it now returns the requested amount of data.